### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/object_detector/CMakeLists.txt
+++ b/object_detector/CMakeLists.txt
@@ -27,7 +27,7 @@ ADD_DEFINITIONS(${QT_DEFINITIONS})
 
 find_package(Eigen3 REQUIRED) #Requiero Eigen 3
 
-find_package(OpenCV 4.2 REQUIRED) #Requiero a OpenCV
+find_package(OpenCV 3.2 REQUIRED) #Requiero a OpenCV
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)


### PR DESCRIPTION
```
zahid@zahid:~/catkin_ws$ catkin_make
Base path: /home/zahid/catkin_ws
Source space: /home/zahid/catkin_ws/src
Build space: /home/zahid/catkin_ws/build
Devel space: /home/zahid/catkin_ws/devel
Install space: /home/zahid/catkin_ws/install
####
#### Running command: "cmake /home/zahid/catkin_ws/src -DCATKIN_DEVEL_PREFIX=/home/zahid/catkin_ws/devel -DCMAKE_INSTALL_PREFIX=/home/zahid/catkin_ws/install -G Unix Makefiles" in "/home/zahid/catkin_ws/build"
####
-- Using CATKIN_DEVEL_PREFIX: /home/zahid/catkin_ws/devel
-- Using CMAKE_PREFIX_PATH: /opt/ros/noetic
-- This workspace overlays: /opt/ros/noetic
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.8.10", minimum required is "3") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python3
-- Using Debian Python package layout
-- Using empy: /usr/lib/python3/dist-packages/em.py
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/zahid/catkin_ws/build/test_results
-- Forcing gtest/gmock from source, though one was otherwise available.
-- Found gtest sources under '/usr/src/googletest': gtests will be built
-- Found gmock sources under '/usr/src/googletest': gmock will be built
-- Found PythonInterp: /usr/bin/python3 (found version "3.8.10") 
-- Using Python nosetests: /usr/bin/nosetests3
-- catkin 0.8.10
-- BUILD_SHARED_LIBS is on
-- BUILD_SHARED_LIBS is on
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- ~~  traversing 6 packages in topological order:
-- ~~  - opencv_tests (unknown)
CMake Warning at /opt/ros/noetic/share/catkin/cmake/catkin_workspace.cmake:89 (message):
  Unknown build type 'ament_python' for package 'opencv_tests'
Call Stack (most recent call first):
  CMakeLists.txt:69 (catkin_workspace)


-- ~~  - vision_opencv (plain cmake)
-- ~~  - cv_bridge (plain cmake)
-- ~~  - image_geometry (plain cmake)
-- ~~  - find_object_2d
-- ~~  - px4
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
CMake Error at /opt/ros/noetic/share/catkin/cmake/catkin_workspace.cmake:100 (message):
  This workspace contains non-catkin packages in it, and catkin cannot build
  a non-homogeneous workspace without isolation.  Try the
  'catkin_make_isolated' command instead.
Call Stack (most recent call first):
  CMakeLists.txt:69 (catkin_workspace)


-- Configuring incomplete, errors occurred!
See also "/home/zahid/catkin_ws/build/CMakeFiles/CMakeOutput.log".
See also "/home/zahid/catkin_ws/build/CMakeFiles/CMakeError.log".
Invoking "cmake" failed
```

```
zahid@zahid:~/catkin_ws$ catkin_make_isolated
Base path: /home/zahid/catkin_ws
Source space: /home/zahid/catkin_ws/src
Build space: /home/zahid/catkin_ws/build_isolated
Devel space: /home/zahid/catkin_ws/devel_isolated
Install space: /home/zahid/catkin_ws/install_isolated
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~  traversing 6 packages in topological order:
~~  - cv_bridge (unknown)
~~  - find_object_2d
~~  - image_geometry (unknown)
~~  - opencv_tests (unknown)
~~  - px4
~~  - vision_opencv (unknown)
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Error: Packages with unknown build types exist
Can not build workspace with packages of unknown build_type
```